### PR TITLE
Replaces custom implementations with existing

### DIFF
--- a/buffertools.js
+++ b/buffertools.js
@@ -129,25 +129,10 @@ buffertools.reverse = unaryAction(function() {
 });
 
 buffertools.toHex = unaryAction(function() {
-  var s = '';
-  for (var i = 0; i < this.length; i++) {
-    var h = this[i].toString(16);
-    if (h.length == 1) h = '0' + h;
-    if (h.length > 2) h = h.substring(1,3);
-    s += h;
-  }
-  return s;
+  return this.toString('hex');
 });
 buffertools.fromHex = unaryAction(function() {
-  var l = this.length;
-  if (l % 2 !== 0) throw new Error('Invalid hex string length');
-  var ret = new Buffer(l / 2);
-  for (var i = 0; i < ret.length; i++) {
-    var c1 = String.fromCharCode(this[2 * i]);
-    var c2 = String.fromCharCode(this[2 * i + 1]);
-    ret[i] = parseInt(c1 + c2, 16);
-  }
-  return ret;
+  return new Buffer(this.toString(), 'hex');
 });
 
 exports.extend = function() {


### PR DESCRIPTION
This pull request removes the custom implementations of `buffertools.toHex` and `buffertools.fromHex` and replaces them with the pre-existing implementation.

It is already assumed that if `Buffer` exists in the namespace, that it replicates the Node `Buffer`, therefore, why not use its pre-existing support for hex instead?
